### PR TITLE
Fix updates files shown in Tinfoil, fixes #33

### DIFF
--- a/Server/Controller/Api.py
+++ b/Server/Controller/Api.py
@@ -53,7 +53,7 @@ def getSearch(request, response):
 	for k, t in Titles.items():
 		f = t.getLatestFile()
 		if f and f.hasValidTicket and (region == None or t.region in region) and (dlc == None or t.isDLC == dlc) and (update == None or t.isUpdate == update) and (demo == None or t.isDemo == demo) and (publisher == None or t.publisher in publisher):
-			o.append({'id': t.id, 'name': t.name, 'version': int(f.version) if f.version else None , 'region': t.region,'size': f.getFileSize(), 'mtime': f.getFileModified() })
+			o.append({'id': t.getId(), 'name': t.getName(), 'version': int(f.version) if f.version else None , 'region': t.getRegion(),'size': f.getFileSize(), 'mtime': f.getFileModified() })
 	response.write(json.dumps(o))
 
 def getTitles(request, response):


### PR DESCRIPTION
Hey,
after some time debugging why my Update files are missing i found out, that the name of all Updates files are null. In the Nsp "class" is a getName() method which searches for update files the real name. So i changed from t.name to t.getName() and now it works lol.
