### PR TITLE
Update checker

### DIFF
--- a/Fs/Nsp.py
+++ b/Fs/Nsp.py
@@ -109,7 +109,7 @@ class Nsp(Pfs0):
 		title = self.title()
 
 		if self.titleId and str(title.version) != None and str(self.version) < str(title.version) and str(title.version) != '0':
-			return {'id': title.id, 'baseId': title.baseId, 'currentVersion': str(title.version), 'newVersion': str(title.version)}
+			return {'id': title.id, 'baseId': title.baseId, 'currentVersion': str(self.version), 'newVersion': str(title.version)}
 
 		if not title.isUpdate and not title.isDLC and Titles.contains(title.updateId):
 			updateFile = self.getUpdateFile()

--- a/Fs/Nsp.py
+++ b/Fs/Nsp.py
@@ -108,7 +108,7 @@ class Nsp(Pfs0):
 	def isUpdateAvailable(self):
 		title = self.title()
 
-		if self.titleId and title.version != None and self.version < title.version and str(title.version) != '0':
+		if self.titleId and str(title.version) != None and str(self.version) < str(title.version) and str(title.version) != '0':
 			return {'id': title.id, 'baseId': title.baseId, 'currentVersion': self.version, 'newVersion': title.version}
 
 		if not title.isUpdate and not title.isDLC and Titles.contains(title.updateId):

--- a/Fs/Nsp.py
+++ b/Fs/Nsp.py
@@ -109,7 +109,7 @@ class Nsp(Pfs0):
 		title = self.title()
 
 		if self.titleId and str(title.version) != None and str(self.version) < str(title.version) and str(title.version) != '0':
-			return {'id': title.id, 'baseId': title.baseId, 'currentVersion': self.version, 'newVersion': title.version}
+			return {'id': title.id, 'baseId': title.baseId, 'currentVersion': str(title.version), 'newVersion': str(title.version)}
 
 		if not title.isUpdate and not title.isDLC and Titles.contains(title.updateId):
 			updateFile = self.getUpdateFile()
@@ -119,8 +119,8 @@ class Nsp(Pfs0):
 
 			updateTitle = Titles.get(title.updateId)
 
-			if updateTitle.version and str(updateTitle.version) != '0':
-				return {'id': updateTitle.id, 'baseId': title.baseId, 'currentVersion': None, 'newVersion': updateTitle.version}
+			if str(updateTitle.version) and str(updateTitle.version) != '0':
+				return {'id': updateTitle.id, 'baseId': title.baseId, 'currentVersion': None, 'newVersion': str(updateTitle.version)}
 
 		return None
 		

--- a/nut.py
+++ b/nut.py
@@ -402,6 +402,7 @@ if __name__ == '__main__':
 		parser.add_argument('-V', action="store_true", help='scan latest title updates from nintendo')
 		parser.add_argument('-o', '--organize', action="store_true", help='rename and move all NSP files')
 		parser.add_argument('-U', '--update-titles', action="store_true", help='update titles db from urls')
+		parser.add_argument('--update-check', action="store_true", help='check for existing titles needing updates')
 		parser.add_argument('-r', '--refresh', action="store_true", help='reads all meta from NSP files and queries CDN for latest version information')
 		parser.add_argument('-R', '--read-rightsids', action="store_true", help='reads all title rights ids from nsps')
 		parser.add_argument('-x', '--extract', nargs='+', help='extract / unpack a NSP')
@@ -494,13 +495,22 @@ if __name__ == '__main__':
 			#for filePath in args.file:
 			#	Print.info(filePath)
 
-	
 		if args.update_titles:
 			nut.initTitles()
 			for url in Config.titleUrls:
 				nut.updateDb(url)
 			Titles.loadTxtDatabases()
 			Titles.save()
+
+		if args.update_check:
+			nut.initTitles()
+			nut.initFiles()
+			for _,game in Nsps.files.items():
+				title = game.title()
+				if title.isUpdate or title.isDLC:
+					if game.isUpdateAvailable():
+						Print.info(title.getName())
+						Print.info(game.isUpdateAvailable())
 
 		if args.submit_keys:
 			nut.initTitles()

--- a/nut.py
+++ b/nut.py
@@ -511,6 +511,7 @@ if __name__ == '__main__':
 					if game.isUpdateAvailable():
 						Print.info(title.getName())
 						Print.info(game.isUpdateAvailable())
+			exit(0)
 
 		if args.submit_keys:
 			nut.initTitles()


### PR DESCRIPTION
Using the new --update-check argument, nut will check which NSP's are missing an update and list them.

Example:
```python3 nut.py --update-check
loaded user guest
                        ,;:;;,
                       ;;;;;
               .=',    ;:;;:,
              /_', "=. ';:;:;
              @=:__,  \,;:;:'
                _(\.=  ;:;;'
               `"_(  _/="`
                `"'
loaded titledb/titles.json in 0.262672 seconds
loaded file list in 0.0757270000000001 seconds
Captain Toad™: Treasure Tracker – Special Episode (Shifty Shrine)
{'id': '01009BF0072D5001', 'baseId': '01009BF0072D4000', 'currentVersion': '0', 'newVersion': '65536'}
DOOM
{'id': '0100416004C00800', 'baseId': '0100416004C00000', 'currentVersion': '131072', 'newVersion': '196608'}
Ape Out
{'id': '01005B100C268800', 'baseId': '01005B100C268000', 'currentVersion': '131072', 'newVersion': '196608'}
Minecraft
{'id': '0100D71004694800', 'baseId': '0100D71004694000', 'currentVersion': '917504', 'newVersion': '983040'}
fin```