### PR TITLE
nut as service under gnu/linux with systemd

### DIFF
--- a/99-NS.rules
+++ b/99-NS.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="3000", GROUP="plugdev"

--- a/nut-wifi.service
+++ b/nut-wifi.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=NUT Wifi Service
+[Service]
+ExecStart=/opt/nut-2.4/nut.py --server
+StandardOutput=null
+User=numerunix
+Group=numerunix
+[Install]
+WantedBy=multi-user.target
+Alias=nut-wifi.service

--- a/nut.service
+++ b/nut.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=NUT USB Service
+[Service]
+ExecStart=/opt/nut-2.4/nut.py --usb
+StandardOutput=null
+[Install]
+WantedBy=multi-user.target
+Alias=nut.service


### PR DESCRIPTION
nutwifi.service and nut.service must be putted in /lib/systemd/system

99-NS.rules must be putted under /etc/udev/rules.d and is the rule for accessing switch via usb under udev, it must not be used with added nut.service, because of nut is runned with root privlegeges.