### PR TITLE
Ignored hidden files on Linux systems (fixes #158)

### DIFF
--- a/nut_impl/nsps.py
+++ b/nut_impl/nsps.py
@@ -32,6 +32,10 @@ def getBaseId(id):
     titleIdNum = int(id, 16)
     return '{:02X}'.format(titleIdNum & 0xFFFFFFFFFFFFE000).zfill(16)
 
+def __is_file_hidden(filepath):
+    name = os.path.basename(os.path.abspath(filepath))
+    return name.startswith('.')
+
 
 def scan(base, force=False):
     global hasScanned
@@ -44,6 +48,8 @@ def scan(base, force=False):
     printer.info(base)
     for root, _, _files in os.walk(base, topdown=False, followlinks=True):
         for name in _files:
+            if __is_file_hidden(name):
+                continue
             suffix = pathlib.Path(name).suffix
 
             if suffix in ['.nsp', '.nsz', '.nsz', '.xci', '.xcz']:
@@ -133,7 +139,7 @@ def load(fileName='conf/files.json'):
                         continue
 
                     path = os.path.abspath(t.path)
-                    if os.path.isfile(path) and os.path.exists(path):
+                    if os.path.isfile(path) and os.path.exists(path) and not __is_file_hidden(path):
                         files[path] = t  # Fs.Nsp(path, None)
 
     except:


### PR DESCRIPTION
* ignored files starting with '.' at nsps scan and load