### PR TITLE
Make `import Server` in `nut.py` conditional

### DIFF
--- a/nut.py
+++ b/nut.py
@@ -30,7 +30,6 @@ import signal
 from nut import Status
 import time
 import colorama
-import Server
 import pprint
 import random
 import shutil
@@ -989,6 +988,7 @@ if __name__ == '__main__':
 			Hook.call("args.post", args)
 
 			if args.server:
+				import Server
 				nut.initTitles()
 				nut.initFiles()
 				Server.run()


### PR DESCRIPTION
Move `import Server` into `if args.server:` code block so it doesn't get imported when it's not used (i.e. on `python nut.py --decompress <filename>`) and doesn't throw an exception on pycurl-less systems (i.e. Windows as per `requirements.txt`, line 20).
Minimal testing done:
before change `--decompress` throws an exception;
after change `--decompress` works, `-S` throws an exception.