### PR TITLE
Update requirement.txt - Add markupsafe==2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ qt-range-slider~=0.2.7
 watchdog~=2.1.6
 certifi>=2021.5.30
 humanize~=3.14
+markupsafe==2.0.1


### PR DESCRIPTION
Need to specify markupsafe version to 2.0.1. After that one they removed 'soft_unicode'.