### PR TITLE
Changed cdn of two files so page loads properly

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -13,10 +13,10 @@
 	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.7/angular-messages.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment.js"></script>
 	<script src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/t-114/svg-assets-cache.js"></script>
-	<script src="https://cdn.gitcdn.link/cdn/angular/bower-material/v1.1.10/angular-material.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.10/angular-material.js"></script>
 	<script src="/script/jquery-3.3.1.min.js"></script>
 	<script src="/script/default.js"></script>
-	<link rel="stylesheet" type="text/css" href="https://cdn.gitcdn.link/cdn/angular/bower-material/v1.1.10/angular-material.css" />
+	<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.10/angular-material.css" />
 	<link rel="stylesheet" type="text/css" href="https://material.angularjs.org/1.1.10/docs.css" />
 	<link rel="stylesheet" type="text/css" href="/style/default.css" />
 </head>


### PR DESCRIPTION
There is an issue where sometimes the web ui does not load or the layout shows no images. Changing the cdn for these links allows the page to load consistently. Related to bug [468](https://github.com/blawar/nut/issues/468).